### PR TITLE
Add features to make interfacing with WorldChunkTool easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Tool to decompress Monster Hunter: World chunkN.bin files and extract the result
 ```
 WorldChunkTool by MHVuze
 
-Usage: WorldChunkTool <chunkN_file|PKG_file> (PKGext)
+Usage: WorldChunkTool <chunkN_file|PKG_file> (PKGext) (AutoConf)
 
 PKGext: use 'false' to turn off PKG file extraction, defaults to 'true'
+
+AutoConf: Use 'true' to bypass confirmation prompts, defaults to 'false'
 ```
 
 *oo2core_5_win64.dll* required. Copy it from the install directory of Monster Hunter: World to the same folder as the WorldChunkTool executable.

--- a/WorldChunkTool/Chunk.cs
+++ b/WorldChunkTool/Chunk.cs
@@ -6,7 +6,7 @@ namespace WorldChunkTool
 {
     class Chunk
     {
-        public static void DecompressChunks(String FileInput, bool FlagPKGExtraction)
+        public static void DecompressChunks(String FileInput, bool FlagPKGExtraction, bool FlagAutoConfirm)
         {
             string NamePKG = $"{Environment.CurrentDirectory}\\{Path.GetFileNameWithoutExtension(FileInput)}.pkg";
             BinaryReader Reader = new BinaryReader(File.Open(FileInput, FileMode.Open));
@@ -68,13 +68,16 @@ namespace WorldChunkTool
 
             Utils.Print("Finished.", true);
             Utils.Print($"Output at: {NamePKG}", false);
-            Console.WriteLine("The PKG file will now be extracted. Press Enter to continue or close window to quit.");
-            Console.Read();
+            
+            if (!FlagAutoConfirm) {
+                Console.WriteLine("The PKG file will now be extracted. Press Enter to continue or close window to quit.");
+                Console.Read();
+            }
 
             Console.SetCursorPosition(0, Console.CursorTop - 1);
             Console.WriteLine("==============================");
-            PKG.ExtractPKG(NamePKG, FlagPKGExtraction);
-            Console.Read();
+            PKG.ExtractPKG(NamePKG, FlagPKGExtraction, FlagAutoConfirm);
+            if (!FlagAutoConfirm) { Console.Read(); }
         }
     }
 }

--- a/WorldChunkTool/PKG.cs
+++ b/WorldChunkTool/PKG.cs
@@ -11,7 +11,7 @@ namespace WorldChunkTool
 {
     class PKG
     {
-        public static void ExtractPKG(string FileInput, bool FlagPKGExtraction)
+        public static void ExtractPKG(string FileInput, bool FlagPKGExtraction, bool FlagAutoConfirm)
         {
             string OutputDirectory = $"{Environment.CurrentDirectory}\\{Path.GetFileNameWithoutExtension(FileInput)}";
             BinaryReader Reader = new BinaryReader(File.Open(FileInput, FileMode.Open));
@@ -90,7 +90,7 @@ namespace WorldChunkTool
 
             Utils.Print("Finished.", true);
             Utils.Print($"Output at: {OutputDirectory}", false);
-            Console.WriteLine("Press Enter to quit");
+            if (!FlagAutoConfirm) { Console.WriteLine("Press Enter to quit"); }
         }
     }
 }

--- a/WorldChunkTool/Program.cs
+++ b/WorldChunkTool/Program.cs
@@ -5,7 +5,7 @@ namespace WorldChunkTool
 {
     class Program
     {
-        /* Error Codes:
+        /* Exit Codes:
          * 0 - No error
          * 1 - Input file missing
          * 2 - oo2core_5_win64.dll file missing

--- a/WorldChunkTool/Program.cs
+++ b/WorldChunkTool/Program.cs
@@ -5,7 +5,13 @@ namespace WorldChunkTool
 {
     class Program
     {
-        static void Main(string[] args)
+        /* Error Codes:
+         * 0 - No error
+         * 1 - Input file missing
+         * 2 - oo2core_5_win64.dll file missing
+         * 3 - Other exception
+         */
+        static int Main(string[] args)
         {
             int MagicChunk = 0x00504D43;
             int MagicPKG = 0x20474B50;
@@ -27,12 +33,12 @@ namespace WorldChunkTool
                 Console.WriteLine("PKGext: use 'false' to turn off PKG file extraction, defaults to 'true'");
                 Console.WriteLine("AutoConf: Use 'true' to bypass confirmation prompts, defaults to 'false'");
                 Console.Read();
-                return;
+                return 0;
             }
 
             // Check file
             FileInput = args[0];
-            if (!File.Exists(FileInput)) { Console.WriteLine("ERROR: Specified file doesn't exist."); Console.Read(); return; }
+            if (!File.Exists(FileInput)) { Console.WriteLine("ERROR: Specified file doesn't exist."); Console.Read(); return 1; }
 
             // Turn PKG extraction output on or off
             if (args.Length > 1) StrPKGExtraction = args[1];
@@ -53,24 +59,24 @@ namespace WorldChunkTool
                     if (!File.Exists($"{AppDomain.CurrentDomain.BaseDirectory}\\oo2core_5_win64.dll")) {
                         Console.WriteLine("ERROR: oo2core_5_win64.dll is missing. Can't decompress chunk file.");
                         if (!FlagAutoConfirm) { Console.Read(); }
-                        return;
+                        return 2;
                     }
                     Chunk.DecompressChunks(FileInput, FlagPKGExtraction, FlagAutoConfirm);
                     if (!FlagAutoConfirm) { Console.Read(); }
-                    return;
+                    return 0;
                 }
                 else if (MagicInputFile == MagicPKG) 
                 {
                     Console.WriteLine("PKG file detected.");
                     PKG.ExtractPKG(FileInput, FlagPKGExtraction, FlagAutoConfirm);
                     if (!FlagAutoConfirm) { Console.Read(); }
-                    return;
+                    return 0;
                 }
                 else 
                 {
                     Console.WriteLine($"ERROR: Invalid magic {MagicInputFile.ToString("X8")}.");
                     if (!FlagAutoConfirm) { Console.Read(); }
-                    return;
+                    return 0;
                 }
             }
             catch (Exception e)
@@ -78,7 +84,7 @@ namespace WorldChunkTool
                 Console.WriteLine("ERROR: The following exception was caught.");
                 Console.WriteLine(e);
                 if (!FlagAutoConfirm) { Console.Read(); }
-                return;
+                return 3;
             }
         }
     }


### PR DESCRIPTION
This PR adds two features.
1. A flag to accept all prompts, meaning the extraction process is completely automated and the program exits on complete.
2. Exit codes for convenient signaling to an executing program.

### Exit Codes

| Code | Description |
| ---- | ----------- |
| 0 | Extraction success |
| 1 | Input file missing |
| 2 | `oo2core_5_win64.dll` file missing |
| 3 | Other exception occurred |

### Motivation
I have been working on a patch tool which automates the process of extracting, patching (applying mods), and installing text (GMD) files. I planned on using WorldChunkTool to extract chunk files, however I ran into the road block of detecting when the program errors, and dealing with user interaction when none is really needed. Implementing these two features would allow other tool to easily depend on this one to extract chunk files for use.