### PR TITLE
Allow to read a file already opened in read mode

### DIFF
--- a/WorldChunkTool/Chunk.cs
+++ b/WorldChunkTool/Chunk.cs
@@ -9,7 +9,7 @@ namespace WorldChunkTool
         public static void DecompressChunks(String FileInput, bool FlagPKGExtraction, bool FlagAutoConfirm, bool FlagUnpackAll, bool FlagPKGDelete)
         {
             string NamePKG = $"{Environment.CurrentDirectory}\\{Path.GetFileNameWithoutExtension(FileInput)}.pkg";
-            BinaryReader Reader = new BinaryReader(File.Open(FileInput, FileMode.Open));
+            BinaryReader Reader = new BinaryReader(File.Open(FileInput, FileMode.Open, FileAccess.Read, FileShare.Read));
 
             // Key = ChunkOffset, Value = ChunkSize
             Dictionary<long, long> MetaChunk = new Dictionary<long, long>();

--- a/WorldChunkTool/Program.cs
+++ b/WorldChunkTool/Program.cs
@@ -72,7 +72,7 @@ namespace WorldChunkTool
         static int ProcessFile(string FileInput)
         {
             if (!File.Exists(FileInput)) { Console.WriteLine("ERROR: Specified file doesn't exist."); Console.Read(); return 1; }
-            using (BinaryReader Reader = new BinaryReader(File.Open(FileInput, FileMode.Open))) MagicInputFile = Reader.ReadInt32();
+            using (BinaryReader Reader = new BinaryReader(File.Open(FileInput, FileMode.Open, FileAccess.Read, FileShare.Read))) MagicInputFile = Reader.ReadInt32();
             if (MagicInputFile == MagicChunk)
             {
                 Console.WriteLine("Chunk file detected.");


### PR DESCRIPTION
I've got those errors when running WorldChunkTool when the `chunk0.bin` file was already open in read mode: (the `<...>` are some local path)
```
System.IO.IOException: The process cannot access the file '<...>\chunk0.bin' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
   at System.IO.File.Open(String path, FileMode mode)
   at WorldChunkTool.Program.ProcessFile(String FileInput) in <...>\WorldChunkTool\WorldChunkTool\Program.cs:line 77
   at WorldChunkTool.Program.Main(String[] args) in <...>\WorldChunkTool\WorldChunkTool\Program.cs:line 62
```

```
System.IO.IOException: The process cannot access the file '<...>\chunk0.bin' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
   at System.IO.File.Open(String path, FileMode mode)
   at WorldChunkTool.Chunk.DecompressChunks(String FileInput, Boolean FlagPKGExtraction, Boolean FlagAutoConfirm, Boolean FlagUnpackAll, Boolean FlagPKGDelete) in <...>\WorldChunkTool\WorldChunkTool\Chunk.cs:line 12
   at WorldChunkTool.Program.ProcessFile(String FileInput) in <...>\WorldChunkTool\WorldChunkTool\Program.cs:line 87
   at WorldChunkTool.Program.Main(String[] args) in <...>\WorldChunkTool\WorldChunkTool\Program.cs:line 62
```

The fix allows to share the file in read mode.